### PR TITLE
Update .htaccess to fix 1and1 problems

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -4,7 +4,10 @@
     </IfModule>
 
     RewriteEngine On
-
+    
+    #For 1and1 users: uncomment the following line to fix the 500 internal server errors
+    #RewriteBase /
+    
     # Redirect Trailing Slashes...
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 


### PR DESCRIPTION
I am using 1&1 for hosting my websites for +6 years. Anyway in the ADK forum you criticised 1and1 :(
In the ADK Forum someone already had a problem.
So the fix for the internal error 500 is to add:
RewriteBase / to the -htaccess in /public.. This fixes every error :)
Working for all versions of BFACP.
Maybe you can add this as a comment to the file?