### PR TITLE
Fixed #163

### DIFF
--- a/app/bfacp/Repositories/Scoreboard/LiveServerRepository.php
+++ b/app/bfacp/Repositories/Scoreboard/LiveServerRepository.php
@@ -388,11 +388,13 @@ class LiveServerRepository extends BaseRepository
 
         $this->setFactions();
 
-        if (isset($presetMessages) && is_array($presetMessages->setting_value)) {
-            $this->data['_presetmessages'] = array_merge([''], $presetMessages->setting_value);
-        } else {
-            $this->data['_presetmessages'] = [];
-        }
+        if (isset($presetMessages) && is_array($presetMessages)) {
+            $this->data['_presetmessages'] = array_merge([''], $presetMessages);
+		} elseif (isset($presetMessages)) {
+			$this->data['_presetmessages']['0'] = $presetMessages;
+		} else {
+			$this->data['_presetmessages'] = [''];
+		}
 
         $this->data['_teams'] = [
             [


### PR DESCRIPTION
If there's just one message, you don't get an array back but just an string. So if $presetMessages is set, but it's not an array, put the string in the first array item. Also the is no 'setting_value', so you would get an 'Trying to get property of non-object' error.