### PR TITLE
Fix bf3 rank image

### DIFF
--- a/app/Battlefield/Player.php
+++ b/app/Battlefield/Player.php
@@ -334,13 +334,9 @@ class Player extends Elegant
                 $rank = $this->GlobalRank;
 
                 if ($rank > 45) {
-                    if ($rank > 100) {
-                        $rank = 100;
-                    }
-
-                    $path = sprintf('images/games/bf3/ranks/large/ss%u.png', $rank);
+                    $path = sprintf('images/games/bf3/ranks/large/ss%u.png', $rank - 45);
                 } else {
-                    $path = sprintf('images/games/bf3/ranks/large/r%u.png', $this->GlobalRank);
+                    $path = sprintf('images/games/bf3/ranks/large/r%u.png', $rank);
                 }
                 break;
 


### PR DESCRIPTION
BF3 ranks span 0-145. In order to yield `ss1` through `ss100`, an offset of 45 needs to be applied to Colonel ranks.